### PR TITLE
refactor: switch from loki update to loki approve

### DIFF
--- a/tools/executors/loki/impl.js
+++ b/tools/executors/loki/impl.js
@@ -23,7 +23,7 @@ const buildCommand = (_context, _options) => {
     command.push('--requireReference');
   }
   if (_options.update) {
-    command.push('update');
+    command.push('approve');
   }
   command.push('--reactUri');
   const buildStorybookOutput = getBuildStorybookOutput(_context);

--- a/tools/executors/loki/src/impl.ts
+++ b/tools/executors/loki/src/impl.ts
@@ -36,7 +36,7 @@ export const buildCommand = (_context: ExecutorContext, _options: Schema) => {
   }
 
   if (_options.update) {
-    command.push('update');
+    command.push('approve');
   }
 
   command.push('--reactUri');


### PR DESCRIPTION
Switch from loki update to loki approve to prune old reference files and update them with the ones generated in the last run.

Closes #80 