### PR TITLE
feat: 460 increase initial height for map snap drawer

### DIFF
--- a/libs/bite-tribe/map/page/src/lib/components/snap-drawer/__specs__/snap-drawer.component.spec.ts
+++ b/libs/bite-tribe/map/page/src/lib/components/snap-drawer/__specs__/snap-drawer.component.spec.ts
@@ -86,7 +86,7 @@ describe('SnapDrawerComponent', () => {
 
       component.ngOnInit();
 
-      expect(computeSnapOffsetsMock).toHaveBeenCalledWith([60, 480]);
+      expect(computeSnapOffsetsMock).toHaveBeenCalledWith([120, 480]);
       expect(getLowestSnapMock).toHaveBeenCalledWith([320, 740]);
       expect(component.translateY).toBe(740);
     });

--- a/libs/bite-tribe/map/page/src/lib/components/snap-drawer/snap-drawer.component.ts
+++ b/libs/bite-tribe/map/page/src/lib/components/snap-drawer/snap-drawer.component.ts
@@ -23,7 +23,7 @@ import { findClosestSnap } from './utils/find-closest-snap';
 })
 export class SnapDrawerComponent implements OnInit, AfterViewInit {
   // default: bite component size
-  snapPixels = input([60, 480]);
+  snapPixels = input([120, 480]);
 
   translateY = 0;
   private dragging = false;


### PR DESCRIPTION
@muhammedgaygisiz I just increased initial height to avoid the "close app" effect when dragging from low down on the screen. The bite picture peeks through like this, but I actually don't mind the little preview. We can go over better UX at a later point, what do you think?
<img width="374" height="669" alt="Screenshot 2025-10-03 at 13 43 59" src="https://github.com/user-attachments/assets/c9dbe8df-ea89-4e18-81a6-9b980cf21f21" />

